### PR TITLE
Retry HTTP request with fresh access token if server returns 401 Unauthorized

### DIFF
--- a/nuts/client.go
+++ b/nuts/client.go
@@ -33,7 +33,7 @@ type OAuth2TokenSource struct {
 	NutsHttpClient *http.Client
 }
 
-func (o OAuth2TokenSource) Token(httpRequest *http.Request, authzServerURL *url.URL, scope string) (*oauth2.Token, error) {
+func (o OAuth2TokenSource) Token(httpRequest *http.Request, authzServerURL *url.URL, scope string, noCache bool) (*oauth2.Token, error) {
 	if o.NutsSubject == "" {
 		return nil, fmt.Errorf("ownDID is required")
 	}
@@ -48,7 +48,12 @@ func (o OAuth2TokenSource) Token(httpRequest *http.Request, authzServerURL *url.
 	// TODO: Might want to support DPoP as well
 	var tokenType = iam.ServiceAccessTokenRequestTokenTypeBearer
 	// TODO: Is this the right context to use?
-	response, err := client.RequestServiceAccessToken(httpRequest.Context(), o.NutsSubject, iam.RequestServiceAccessTokenJSONRequestBody{
+	params := iam.RequestServiceAccessTokenParams{}
+	if noCache {
+		noCacheValue := "no-cache"
+		params.CacheControl = &noCacheValue
+	}
+	response, err := client.RequestServiceAccessToken(httpRequest.Context(), o.NutsSubject, &params, iam.RequestServiceAccessTokenJSONRequestBody{
 		AuthorizationServer: authzServerURL.String(),
 		Credentials:         &additionalCredentials,
 		Scope:               scope,

--- a/nuts/client_test.go
+++ b/nuts/client_test.go
@@ -17,7 +17,11 @@ import (
 func TestOAuth2TokenSource_Token(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		mux := http.NewServeMux()
+		capturedHeaders := make(http.Header)
 		mux.HandleFunc("/internal/auth/v2/123abc/request-service-access-token", func(w http.ResponseWriter, r *http.Request) {
+			for k, v := range r.Header {
+				capturedHeaders[k] = v
+			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"access_token":"test","token_type":"bearer","expires_in":3600}`))
@@ -30,15 +34,25 @@ func TestOAuth2TokenSource_Token(t *testing.T) {
 		expectedAuthServerURL, _ := url.Parse("https://auth.example.com")
 		httpRequest, _ := http.NewRequestWithContext(context.Background(), "GET", "https://resource.example.com", nil)
 
-		token, err := tokenSource.Token(httpRequest, expectedAuthServerURL, "test")
+		t.Run("no Cache-Control headers", func(t *testing.T) {
+			token, err := tokenSource.Token(httpRequest, expectedAuthServerURL, "test", false)
 
-		require.NoError(t, err)
-		require.NotNil(t, token)
+			require.NoError(t, err)
+			require.NotNil(t, token)
 
-		require.Equal(t, "test", token.AccessToken)
-		require.Equal(t, "bearer", token.TokenType)
-		require.Greater(t, token.Expiry.Unix(), time.Now().Unix())
-		require.Less(t, token.Expiry.Unix(), time.Now().Add(2*time.Hour).Unix())
+			require.Equal(t, "test", token.AccessToken)
+			require.Equal(t, "bearer", token.TokenType)
+			require.Greater(t, token.Expiry.Unix(), time.Now().Unix())
+			require.Less(t, token.Expiry.Unix(), time.Now().Add(2*time.Hour).Unix())
+		})
+		t.Run("specify Cache-Control: no-cache", func(t *testing.T) {
+			token, err := tokenSource.Token(httpRequest, expectedAuthServerURL, "test", true)
+
+			require.NoError(t, err)
+			require.NotNil(t, token)
+			
+			require.Equal(t, "no-cache", capturedHeaders.Get("Cache-Control"))
+		})
 	})
 	t.Run("additional credentials", func(t *testing.T) {
 		mux := http.NewServeMux()
@@ -62,7 +76,7 @@ func TestOAuth2TokenSource_Token(t *testing.T) {
 		})
 		httpRequest, _ := http.NewRequestWithContext(requestCtx, "GET", "https://resource.example.com", nil)
 
-		token, err := tokenSource.Token(httpRequest, expectedAuthServerURL, "test")
+		token, err := tokenSource.Token(httpRequest, expectedAuthServerURL, "test", false)
 
 		require.NoError(t, err)
 		require.NotNil(t, token)

--- a/nuts/iam/generated.go
+++ b/nuts/iam/generated.go
@@ -208,13 +208,18 @@ type TokenIntrospectionResponse struct {
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
-// TokenResponse Token Responses are made as defined in (RFC6749)[https://datatracker.ietf.org/doc/html/rfc6749#section-5.1]
+// TokenResponse Token Responses are made as defined in (RFC6749)[https://datatracker.ietf.org/doc/html/rfc6749#section-5.1].
+// With an additional field 'expires_at' used for cached tokens to recalculate 'expires_in'.
+// The field 'dpop_kid' is added from (RFC9449)[https://datatracker.ietf.org/doc/html/rfc9449].
 type TokenResponse struct {
 	// AccessToken The access token issued by the authorization server.
 	AccessToken string `json:"access_token"`
 
 	// DpopKid The kid of the DPoP key that is used to sign dpop headers.
 	DpopKid *string `json:"dpop_kid,omitempty"`
+
+	// ExpiresAt The expiration time of the access token in seconds since UNIX epoch.
+	ExpiresAt *int `json:"expires_at,omitempty"`
 
 	// ExpiresIn The lifetime in seconds of the access token.
 	ExpiresIn *int    `json:"expires_in,omitempty"`
@@ -295,6 +300,20 @@ type RequestOpenid4VCICredentialIssuanceJSONBody struct {
 
 	// WalletDid The DID to which the Verifiable Credential must be issued. Must be owned by the given subject.
 	WalletDid string `json:"wallet_did"`
+}
+
+// RequestServiceAccessTokenParams defines parameters for RequestServiceAccessToken.
+type RequestServiceAccessTokenParams struct {
+	// CacheControl Access tokens are cached by the Nuts node, specify Cache-Control: no-cache to bypass the cache.
+	// This forces the Nuts node to request a new access token from the authorizer.
+	//
+	// A valid use case for this is when the Resource Server rejects the access token with 401 Unauthorized.
+	// It could be that the Authorization Server lost the access token due to a server restart,
+	// in combination with (non-recommended) usage of in-memory session storage.
+	// The local Nuts node then still considers the token valid, while the Authorization Server does not.
+	//
+	// Note that this should not be used under normal circumstances, as it will increase round trip time and load on both the requester and authorizer.
+	CacheControl *string `json:"Cache-Control,omitempty"`
 }
 
 // IntrospectAccessTokenFormdataRequestBody defines body for IntrospectAccessToken for application/x-www-form-urlencoded ContentType.
@@ -807,9 +826,9 @@ type ClientInterface interface {
 	RequestOpenid4VCICredentialIssuance(ctx context.Context, subjectID string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RequestServiceAccessTokenWithBody request with any body
-	RequestServiceAccessTokenWithBody(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	RequestServiceAccessTokenWithBody(ctx context.Context, subjectID string, params *RequestServiceAccessTokenParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	RequestServiceAccessToken(ctx context.Context, subjectID string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	RequestServiceAccessToken(ctx context.Context, subjectID string, params *RequestServiceAccessTokenParams, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RequestUserAccessTokenWithBody request with any body
 	RequestUserAccessTokenWithBody(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -949,8 +968,8 @@ func (c *Client) RequestOpenid4VCICredentialIssuance(ctx context.Context, subjec
 	return c.Client.Do(req)
 }
 
-func (c *Client) RequestServiceAccessTokenWithBody(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRequestServiceAccessTokenRequestWithBody(c.Server, subjectID, contentType, body)
+func (c *Client) RequestServiceAccessTokenWithBody(ctx context.Context, subjectID string, params *RequestServiceAccessTokenParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestServiceAccessTokenRequestWithBody(c.Server, subjectID, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -961,8 +980,8 @@ func (c *Client) RequestServiceAccessTokenWithBody(ctx context.Context, subjectI
 	return c.Client.Do(req)
 }
 
-func (c *Client) RequestServiceAccessToken(ctx context.Context, subjectID string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRequestServiceAccessTokenRequest(c.Server, subjectID, body)
+func (c *Client) RequestServiceAccessToken(ctx context.Context, subjectID string, params *RequestServiceAccessTokenParams, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestServiceAccessTokenRequest(c.Server, subjectID, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1243,18 +1262,18 @@ func NewRequestOpenid4VCICredentialIssuanceRequestWithBody(server string, subjec
 }
 
 // NewRequestServiceAccessTokenRequest calls the generic RequestServiceAccessToken builder with application/json body
-func NewRequestServiceAccessTokenRequest(server string, subjectID string, body RequestServiceAccessTokenJSONRequestBody) (*http.Request, error) {
+func NewRequestServiceAccessTokenRequest(server string, subjectID string, params *RequestServiceAccessTokenParams, body RequestServiceAccessTokenJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewRequestServiceAccessTokenRequestWithBody(server, subjectID, "application/json", bodyReader)
+	return NewRequestServiceAccessTokenRequestWithBody(server, subjectID, params, "application/json", bodyReader)
 }
 
 // NewRequestServiceAccessTokenRequestWithBody generates requests for RequestServiceAccessToken with any type of body
-func NewRequestServiceAccessTokenRequestWithBody(server string, subjectID string, contentType string, body io.Reader) (*http.Request, error) {
+func NewRequestServiceAccessTokenRequestWithBody(server string, subjectID string, params *RequestServiceAccessTokenParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1285,6 +1304,21 @@ func NewRequestServiceAccessTokenRequestWithBody(server string, subjectID string
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.CacheControl != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "Cache-Control", runtime.ParamLocationHeader, *params.CacheControl)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Cache-Control", headerParam0)
+		}
+
+	}
 
 	return req, nil
 }
@@ -1408,9 +1442,9 @@ type ClientWithResponsesInterface interface {
 	RequestOpenid4VCICredentialIssuanceWithResponse(ctx context.Context, subjectID string, body RequestOpenid4VCICredentialIssuanceJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestOpenid4VCICredentialIssuanceResponse, error)
 
 	// RequestServiceAccessTokenWithBodyWithResponse request with any body
-	RequestServiceAccessTokenWithBodyWithResponse(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error)
+	RequestServiceAccessTokenWithBodyWithResponse(ctx context.Context, subjectID string, params *RequestServiceAccessTokenParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error)
 
-	RequestServiceAccessTokenWithResponse(ctx context.Context, subjectID string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error)
+	RequestServiceAccessTokenWithResponse(ctx context.Context, subjectID string, params *RequestServiceAccessTokenParams, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error)
 
 	// RequestUserAccessTokenWithBodyWithResponse request with any body
 	RequestUserAccessTokenWithBodyWithResponse(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestUserAccessTokenResponse, error)
@@ -1739,16 +1773,16 @@ func (c *ClientWithResponses) RequestOpenid4VCICredentialIssuanceWithResponse(ct
 }
 
 // RequestServiceAccessTokenWithBodyWithResponse request with arbitrary body returning *RequestServiceAccessTokenResponse
-func (c *ClientWithResponses) RequestServiceAccessTokenWithBodyWithResponse(ctx context.Context, subjectID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error) {
-	rsp, err := c.RequestServiceAccessTokenWithBody(ctx, subjectID, contentType, body, reqEditors...)
+func (c *ClientWithResponses) RequestServiceAccessTokenWithBodyWithResponse(ctx context.Context, subjectID string, params *RequestServiceAccessTokenParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error) {
+	rsp, err := c.RequestServiceAccessTokenWithBody(ctx, subjectID, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseRequestServiceAccessTokenResponse(rsp)
 }
 
-func (c *ClientWithResponses) RequestServiceAccessTokenWithResponse(ctx context.Context, subjectID string, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error) {
-	rsp, err := c.RequestServiceAccessToken(ctx, subjectID, body, reqEditors...)
+func (c *ClientWithResponses) RequestServiceAccessTokenWithResponse(ctx context.Context, subjectID string, params *RequestServiceAccessTokenParams, body RequestServiceAccessTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestServiceAccessTokenResponse, error) {
+	rsp, err := c.RequestServiceAccessToken(ctx, subjectID, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/oauth2/client.go
+++ b/oauth2/client.go
@@ -1,9 +1,11 @@
 package oauth2
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -40,16 +42,52 @@ func (o *Transport) RoundTrip(httpRequest *http.Request) (*http.Response, error)
 		client = o.UnderlyingTransport
 	}
 
-	token, err := o.requestToken(httpRequest)
+	var requestBody []byte = nil
+	if httpRequest.Body != nil {
+		requestBody, err = io.ReadAll(httpRequest.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading request body: %w", err)
+		}
+	}
+
+	const maxTries = 2
+	requestFreshToken := false
+	var httpResponse *http.Response
+	var errs []error
+	for tryNum := 1; tryNum <= maxTries; tryNum++ {
+		httpRequestCopy := httpRequest.Clone(httpRequest.Context())
+		if requestBody != nil {
+			httpRequestCopy.Body = io.NopCloser(bytes.NewReader(requestBody))
+		}
+		httpResponse, err = o.attemptRequest(client, httpRequestCopy, requestFreshToken)
+		if err != nil {
+			errs = append(errs, err)
+			if tryNum < maxTries {
+				// Retry
+				continue
+			}
+			return nil, fmt.Errorf("HTTP request failed after %d attempts: %w", tryNum, errors.Join(errs...))
+		}
+		requestFreshToken = false
+		if httpResponse.StatusCode == http.StatusUnauthorized {
+			// Should be retried with a new token.
+			requestFreshToken = true
+			continue
+		}
+	}
+	return httpResponse, err
+}
+
+func (o *Transport) attemptRequest(client http.RoundTripper, httpRequest *http.Request, requestFreshToken bool) (*http.Response, error) {
+	token, err := o.requestToken(httpRequest, requestFreshToken)
 	if err != nil {
 		return nil, fmt.Errorf("OAuth2 token request (resource=%s): %w", httpRequest.URL.String(), err)
 	}
-	httpRequest = httpRequest.Clone(httpRequest.Context())
 	httpRequest.Header.Set("Authorization", fmt.Sprintf("%s %s", token.TokenType, token.AccessToken))
 	return client.RoundTrip(httpRequest)
 }
 
-func (o *Transport) requestToken(httpRequest *http.Request) (*Token, error) {
+func (o *Transport) requestToken(httpRequest *http.Request, noCache bool) (*Token, error) {
 	// Use the scope from the request context if available.
 	scope := o.Scope
 	if ctxScope, ok := httpRequest.Context().Value(withScopeContextKeyInstance).(string); ok {
@@ -59,7 +97,7 @@ func (o *Transport) requestToken(httpRequest *http.Request) (*Token, error) {
 		return nil, errors.New("scope is required")
 	}
 
-	token, err := o.TokenSource.Token(httpRequest, o.AuthzServerURL, scope)
+	token, err := o.TokenSource.Token(httpRequest, o.AuthzServerURL, scope, noCache)
 	if err != nil {
 		return nil, err
 	}

--- a/oauth2/client_test.go
+++ b/oauth2/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
 )
 
@@ -36,36 +37,158 @@ func TestClient_RoundTrip(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, httpResponse.StatusCode)
 		})
-		t.Run("POST request (request body is buffered to be sent multiple times)", func(t *testing.T) {
-			mux := http.NewServeMux()
-			var capturedBody []byte
-			mux.HandleFunc("POST /resource", func(w http.ResponseWriter, r *http.Request) {
-				if r.Header.Get("Authorization") != "Bearer token" {
+		t.Run("401 Unauthorized retries HTTP request with fresh token", func(t *testing.T) {
+			t.Run("GET request", func(t *testing.T) {
+				mux := http.NewServeMux()
+				var capturedBody []byte
+				mux.HandleFunc("GET /resource", func(w http.ResponseWriter, r *http.Request) {
+					// Reject the first token
+					if r.Header.Get("Authorization") != "Bearer token2" {
+						w.WriteHeader(http.StatusUnauthorized)
+						_, _ = w.Write([]byte("Unauthorized"))
+						return
+					}
+					var err error
+					capturedBody, err = io.ReadAll(r.Body)
+					require.NoError(t, err)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("Access granted"))
+				})
+				httpServer := httptest.NewServer(mux)
+				client := http.Client{
+					Transport: &Transport{
+						TokenSource: &incrementingAuthTokenSource{},
+						Scope:       "test-scope",
+					},
+				}
+
+				httpResponse, err := client.Get(httpServer.URL + "/resource")
+
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+				require.Empty(t, string(capturedBody))
+			})
+			t.Run("max. number of retries reached", func(t *testing.T) {
+				mux := http.NewServeMux()
+				mux.HandleFunc("GET /resource", func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusUnauthorized)
 					_, _ = w.Write([]byte("Unauthorized"))
-					return
+				})
+				httpServer := httptest.NewServer(mux)
+				tokenSource := &incrementingAuthTokenSource{}
+				client := http.Client{
+					Transport: &Transport{
+						TokenSource: tokenSource,
+						Scope:       "test-scope",
+					},
 				}
-				var err error
-				capturedBody, err = io.ReadAll(r.Body)
+
+				httpResponse, err := client.Get(httpServer.URL + "/resource")
+
 				require.NoError(t, err)
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte("Access granted"))
+				require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
+				require.Equal(t, 2, tokenSource.count)
 			})
-			httpServer := httptest.NewServer(mux)
-			client := http.Client{
-				Transport: &Transport{
-					TokenSource: &noAuthTokenSource{},
-					Scope:       "test-scope",
-				},
-			}
+			t.Run("POST request (request body is buffered to be sent multiple times)", func(t *testing.T) {
+				mux := http.NewServeMux()
+				var capturedBody []byte
+				mux.HandleFunc("POST /resource", func(w http.ResponseWriter, r *http.Request) {
+					// Reject the first token
+					if r.Header.Get("Authorization") != "Bearer token2" {
+						w.WriteHeader(http.StatusUnauthorized)
+						_, _ = w.Write([]byte("Unauthorized"))
+						return
+					}
+					var err error
+					capturedBody, err = io.ReadAll(r.Body)
+					require.NoError(t, err)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("Access granted"))
+				})
+				httpServer := httptest.NewServer(mux)
+				client := http.Client{
+					Transport: &Transport{
+						TokenSource: &incrementingAuthTokenSource{},
+						Scope:       "test-scope",
+					},
+				}
 
-			httpResponse, err := client.Post(httpServer.URL+"/resource", "application/json", bytes.NewReader([]byte("test")))
+				httpResponse, err := client.Post(httpServer.URL+"/resource", "application/json", bytes.NewReader([]byte("test")))
 
-			require.NoError(t, err)
-			require.Equal(t, http.StatusOK, httpResponse.StatusCode)
-			require.Equal(t, "test", string(capturedBody))
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+				require.Equal(t, "test", string(capturedBody))
+			})
+			t.Run("POST request with form values", func(t *testing.T) {
+				mux := http.NewServeMux()
+				var capturedBody []byte
+				mux.HandleFunc("POST /resource", func(w http.ResponseWriter, r *http.Request) {
+					// Reject the first token
+					if r.Header.Get("Authorization") != "Bearer token2" {
+						w.WriteHeader(http.StatusUnauthorized)
+						_, _ = w.Write([]byte("Unauthorized"))
+						return
+					}
+					var err error
+					capturedBody, err = io.ReadAll(r.Body)
+					require.NoError(t, err)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("Access granted"))
+				})
+				httpServer := httptest.NewServer(mux)
+				client := http.Client{
+					Transport: &Transport{
+						TokenSource: &incrementingAuthTokenSource{},
+						Scope:       "test-scope",
+					},
+				}
+
+				httpResponse, err := client.PostForm(httpServer.URL+"/resource", url.Values{"key": {"value"}})
+
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+				require.Equal(t, "key=value", string(capturedBody))
+			})
 		})
 	})
+	t.Run("unreachable server", func(t *testing.T) {
+		httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		}))
+		httpServer.Close()
+
+		tokenSource := &incrementingAuthTokenSource{}
+		client := http.Client{
+			Transport: &Transport{
+				TokenSource: tokenSource,
+				Scope:       "test-scope",
+			},
+		}
+
+		httpResponse, err := client.Get(httpServer.URL + "/resource")
+
+		require.ErrorContains(t, err, "HTTP request failed after 2 attempts")
+		require.Nil(t, httpResponse)
+		require.Equal(t, 1, tokenSource.count)
+	})
+}
+
+var _ TokenSource = &incrementingAuthTokenSource{}
+
+type incrementingAuthTokenSource struct {
+	count int
+}
+
+func (i *incrementingAuthTokenSource) Token(_ *http.Request, _ *url.URL, _ string, freshToken bool) (*Token, error) {
+	if i.count == 0 {
+		i.count = 1
+	}
+	if freshToken {
+		i.count++
+	}
+	return &Token{
+		AccessToken: "token" + strconv.Itoa(i.count),
+		TokenType:   "Bearer",
+	}, nil
 }
 
 var _ TokenSource = &noAuthTokenSource{}
@@ -73,7 +196,7 @@ var _ TokenSource = &noAuthTokenSource{}
 type noAuthTokenSource struct {
 }
 
-func (n noAuthTokenSource) Token(httpRequest *http.Request, authzServerURL *url.URL, scope string) (*Token, error) {
+func (n noAuthTokenSource) Token(httpRequest *http.Request, authzServerURL *url.URL, scope string, _ bool) (*Token, error) {
 	return &Token{
 		AccessToken: "token",
 		TokenType:   "Bearer",

--- a/oauth2/tokensource.go
+++ b/oauth2/tokensource.go
@@ -13,5 +13,5 @@ type Token struct {
 }
 
 type TokenSource interface {
-	Token(httpRequest *http.Request, authzServerURL *url.URL, scope string) (*Token, error)
+	Token(httpRequest *http.Request, authzServerURL *url.URL, scope string, noCache bool) (*Token, error)
 }


### PR DESCRIPTION
If `Cache-Control: no-cache` is specified, a new access token is requested and cache bypassed.